### PR TITLE
Add {names} variable to output filename pattern

### DIFF
--- a/livekeet.py
+++ b/livekeet.py
@@ -181,8 +181,9 @@ DEFAULT_CONFIG = """\
 [output]
 # Directory for transcripts (empty = current directory)
 directory = ""
-# Filename pattern: {date}, {time}, {datetime}, or any static name
-# Examples: "{datetime}.md", "{date}-meeting.md", "transcript.md"
+# Filename pattern: {date}, {time}, {datetime}, {names}, or any static name
+# {names} expands to --with/-w names joined by dashes (e.g., John-Paul)
+# Examples: "{datetime}.md", "{datetime}-{names}.md", "{date}-meeting.md"
 filename = "{datetime}.md"
 
 [speaker]
@@ -251,20 +252,38 @@ Models (downloaded on first use):
   parakeet-tdt-0.6b-v3  Multilingual, 25 languages (--multilingual)""")
 
 
-def resolve_output_path(config: dict, output_arg: str | None) -> Path:
+def _expand_filename(pattern: str, names: list[str]) -> str:
+    """Expand a filename pattern with datetime and names variables."""
+    now = datetime.now()
+    # Sanitize names: strip path separators so Path().stem can't truncate
+    safe_names = [n.replace("/", "_").replace("\\", "_") for n in names]
+    names_str = "-".join(safe_names)
+    filename = pattern.format(
+        date=now.strftime("%Y-%m-%d"),
+        time=now.strftime("%H-%M-%S"),
+        datetime=now.strftime("%Y-%m-%d-%H%M%S"),
+        names=names_str,
+    )
+    # Clean up stray dashes from empty {names} (e.g., "2024-01-15-143025-.md")
+    base = filename.rsplit(".", 1)
+    stem = base[0]
+    suffix = f".{base[1]}" if len(base) > 1 else ""
+    stem = re.sub(r"-{2,}", "-", stem)  # collapse multiple dashes
+    stem = stem.strip("-")  # strip leading/trailing dashes
+    return stem + suffix
+
+
+def resolve_output_path(config: dict, output_arg: str | None, names: list[str] | None = None) -> Path:
     """Resolve the output file path from config and CLI args."""
+    if names is None:
+        names = []
     if output_arg:
         # CLI argument takes precedence
         path = Path(output_arg)
         if path.is_dir():
             # Use config filename pattern inside the given directory
-            now = datetime.now()
             pattern = config["output"]["filename"]
-            filename = pattern.format(
-                date=now.strftime("%Y-%m-%d"),
-                time=now.strftime("%H-%M-%S"),
-                datetime=now.strftime("%Y-%m-%d-%H%M%S"),
-            )
+            filename = _expand_filename(pattern, names)
             return path / filename
         if not path.suffix:
             path = path.with_suffix(".md")
@@ -275,12 +294,7 @@ def resolve_output_path(config: dict, output_arg: str | None) -> Path:
     directory = config["output"]["directory"]
 
     # Expand pattern
-    now = datetime.now()
-    filename = pattern.format(
-        date=now.strftime("%Y-%m-%d"),
-        time=now.strftime("%H-%M-%S"),
-        datetime=now.strftime("%Y-%m-%d-%H%M%S"),
-    )
+    filename = _expand_filename(pattern, names)
 
     if directory:
         base_dir = Path(directory).expanduser()
@@ -367,7 +381,7 @@ def warn_flag_interactions(args: argparse.Namespace) -> None:
     if args.multilingual and args.model:
         print("Warning: --multilingual overrides --model", file=sys.stderr)
     if args.mic_only and args.other_speaker:
-        print("Warning: --with is ignored in --mic-only mode (system audio disabled)", file=sys.stderr)
+        print("Warning: --with speaker labels are ignored in --mic-only mode (system audio disabled), but still affect the output filename", file=sys.stderr)
     if getattr(args, "engine", None) == "pyannote" and not getattr(args, "diarize", False) and not args.other_speaker:
         print("Note: --engine pyannote implies --diarize", file=sys.stderr)
 
@@ -1275,8 +1289,15 @@ Examples:
                 print("Or use --mic-only to capture microphone only")
                 sys.exit(1)
 
+    # Parse comma-separated speaker names (needed for output filename)
+    if args.other_speaker:
+        other_names = [n.strip() for n in args.other_speaker.split(",") if n.strip()]
+    else:
+        other_names = []
+    other_name = other_names[0] if other_names else "Other"
+
     # Resolve output path
-    output_path = resolve_output_path(config, args.output)
+    output_path = resolve_output_path(config, args.output, other_names)
     output_path, suffixed = ensure_unique_path(output_path)
     if suffixed:
         print(f"Output exists; saving to {output_path}")
@@ -1287,13 +1308,6 @@ Examples:
         device, device_name = resolve_device(args.device)
         if device_name:
             print(f"Using input device: {device_name}")
-
-    # Parse comma-separated speaker names
-    if args.other_speaker:
-        other_names = [n.strip() for n in args.other_speaker.split(",") if n.strip()]
-    else:
-        other_names = []
-    other_name = other_names[0] if other_names else "Other"
 
     # Get speaker names
     speaker_name = config["speaker"]["name"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,7 +91,7 @@ def test_warn_with_ignored_in_mic_only(capsys):
     args = SimpleNamespace(multilingual=False, model=None, mic_only=True, other_speaker="John")
     livekeet.warn_flag_interactions(args)
     captured = capsys.readouterr()
-    assert "--with is ignored in --mic-only mode" in captured.err
+    assert "--with speaker labels are ignored in --mic-only mode" in captured.err
 
 
 def test_comma_separated_with_names():


### PR DESCRIPTION
## Summary

- Adds a `{names}` variable to the config filename pattern (`~/.config/livekeet/config.toml`), which expands to the `--with`/`-w` speaker names joined by dashes
- When no names are provided, stray dashes are automatically cleaned up so filenames stay clean
- No change to default behavior — only activates when `{names}` is used in the pattern

## Examples

With `filename = "{datetime}-{names}.md"` in config:

| Command | Output |
|---|---|
| `livekeet -w John` | `2026-03-03-145716-John.md` |
| `livekeet -w John,Paul` | `2026-03-03-145716-John-Paul.md` |
| `livekeet` (no -w) | `2026-03-03-145716.md` |

## Test plan

- [ ] Run `livekeet -w John` with `filename = "{datetime}-{names}.md"` in config — verify filename includes `John`
- [ ] Run `livekeet -w John,Paul` — verify filename includes `John-Paul`
- [ ] Run `livekeet` without `-w` — verify no trailing dash in filename
- [ ] Run with default config (`{datetime}.md`) — verify no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Output filenames now support a `{names}` placeholder to automatically include speaker names in the filename pattern.
  * Added `--with` command-line option to specify additional speaker names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->