### PR TITLE
Add helpful error for gated pyannote model access

### DIFF
--- a/diarization_pyannote.py
+++ b/diarization_pyannote.py
@@ -44,10 +44,21 @@ class PyannoteDiarizer:
 
         from pyannote.audio import Pipeline
 
-        self._pipeline = Pipeline.from_pretrained(
-            "pyannote/speaker-diarization-3.1",
-            token=token,
-        )
+        try:
+            self._pipeline = Pipeline.from_pretrained(
+                "pyannote/speaker-diarization-3.1",
+                token=token,
+            )
+        except Exception as e:
+            if "403" in str(e):
+                raise RuntimeError(
+                    "Access denied to gated pyannote models. "
+                    "You must accept the user conditions for each model:\n"
+                    "  1. https://huggingface.co/pyannote/speaker-diarization-3.1\n"
+                    "  2. https://huggingface.co/pyannote/segmentation-3.0\n"
+                    "Then retry. Make sure your HF token has the correct permissions."
+                ) from e
+            raise
 
     def _run_pipeline(self, audio_path: Path) -> list[tuple[float, float, str]]:
         """Run pyannote on a mono WAV file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "livekeet"
-version = "0.1.16"
+version = "0.1.17"
 description = "Real-time audio transcription to markdown using NVIDIA Parakeet via MLX. Optimized for Apple Silicon."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_diarization_pyannote.py
+++ b/tests/test_diarization_pyannote.py
@@ -94,6 +94,23 @@ class TestPyannoteDiarizerInit:
             if env_backup is not None:
                 os.environ["HF_TOKEN"] = env_backup
 
+    def test_raises_helpful_message_on_403(self):
+        """A 403 from gated models should show URLs to accept conditions."""
+        mock_pipeline_cls = MagicMock()
+        mock_pipeline_cls.from_pretrained.side_effect = Exception(
+            "403 Client Error: Forbidden"
+        )
+        mock_module = MagicMock()
+        mock_module.Pipeline = mock_pipeline_cls
+
+        with patch.dict("os.environ", {"HF_TOKEN": "hf_test123"}):
+            with patch.dict("sys.modules", {"pyannote.audio": mock_module, "pyannote": MagicMock()}):
+                import importlib
+                import diarization_pyannote
+                importlib.reload(diarization_pyannote)
+                with pytest.raises(RuntimeError, match="Access denied to gated pyannote models"):
+                    diarization_pyannote.PyannoteDiarizer()
+
     def test_uses_env_token(self):
         """Verify HF_TOKEN env var is picked up (pipeline import mocked)."""
         mock_pipeline_cls = MagicMock()

--- a/tests/test_diarization_pyannote.py
+++ b/tests/test_diarization_pyannote.py
@@ -94,40 +94,41 @@ class TestPyannoteDiarizerInit:
             if env_backup is not None:
                 os.environ["HF_TOKEN"] = env_backup
 
+    @staticmethod
+    def _patched_pipeline(side_effect=None):
+        """Patch pyannote.audio with a mock Pipeline and reload the module."""
+        from contextlib import contextmanager
+
+        @contextmanager
+        def ctx():
+            mock_pipeline_cls = MagicMock()
+            if side_effect:
+                mock_pipeline_cls.from_pretrained.side_effect = side_effect
+            else:
+                mock_pipeline_cls.from_pretrained.return_value = MagicMock()
+            mock_module = MagicMock()
+            mock_module.Pipeline = mock_pipeline_cls
+
+            with patch.dict("os.environ", {"HF_TOKEN": "hf_test123"}):
+                with patch.dict("sys.modules", {"pyannote.audio": mock_module, "pyannote": MagicMock()}):
+                    import importlib
+                    import diarization_pyannote
+                    importlib.reload(diarization_pyannote)
+                    yield diarization_pyannote, mock_pipeline_cls
+
+        return ctx()
+
     def test_raises_helpful_message_on_403(self):
         """A 403 from gated models should show URLs to accept conditions."""
-        mock_pipeline_cls = MagicMock()
-        mock_pipeline_cls.from_pretrained.side_effect = Exception(
-            "403 Client Error: Forbidden"
-        )
-        mock_module = MagicMock()
-        mock_module.Pipeline = mock_pipeline_cls
-
-        with patch.dict("os.environ", {"HF_TOKEN": "hf_test123"}):
-            with patch.dict("sys.modules", {"pyannote.audio": mock_module, "pyannote": MagicMock()}):
-                import importlib
-                import diarization_pyannote
-                importlib.reload(diarization_pyannote)
-                with pytest.raises(RuntimeError, match="Access denied to gated pyannote models"):
-                    diarization_pyannote.PyannoteDiarizer()
+        with self._patched_pipeline(side_effect=Exception("403 Client Error: Forbidden")) as (mod, _):
+            with pytest.raises(RuntimeError, match="Access denied to gated pyannote models"):
+                mod.PyannoteDiarizer()
 
     def test_uses_env_token(self):
         """Verify HF_TOKEN env var is picked up (pipeline import mocked)."""
-        mock_pipeline_cls = MagicMock()
-        mock_pipeline_cls.from_pretrained.return_value = MagicMock()
-        mock_module = MagicMock()
-        mock_module.Pipeline = mock_pipeline_cls
-
-        with patch.dict("os.environ", {"HF_TOKEN": "hf_test123"}):
-            with patch.dict("sys.modules", {"pyannote.audio": mock_module, "pyannote": MagicMock()}):
-                import importlib
-                import diarization_pyannote
-                importlib.reload(diarization_pyannote)
-                try:
-                    diarizer = diarization_pyannote.PyannoteDiarizer()
-                    mock_pipeline_cls.from_pretrained.assert_called_once()
-                except Exception:
-                    pass
+        with self._patched_pipeline() as (mod, mock_cls):
+            mod.PyannoteDiarizer()
+            mock_cls.from_pretrained.assert_called_once()
 
 
 # --- check_pyannote_installed ---

--- a/uv.lock
+++ b/uv.lock
@@ -1057,7 +1057,7 @@ wheels = [
 
 [[package]]
 name = "livekeet"
-version = "0.1.12"
+version = "0.1.17"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
@@ -2710,6 +2710,11 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
     { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/39/590742415c3030551944edc2ddc273ea1fdfe8ffb2780992e824f1ebee98/torch-2.10.0-3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b1d5e2aba4eb7f8e87fbe04f86442887f9167a35f092afe4c237dfcaaef6e328", size = 915632474, upload-time = "2026-03-11T14:15:13.666Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8e/34949484f764dde5b222b7fe3fede43e4a6f0da9d7f8c370bb617d629ee2/torch-2.10.0-3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0228d20b06701c05a8f978357f657817a4a63984b0c90745def81c18aedfa591", size = 915523882, upload-time = "2026-03-11T14:14:46.311Z" },
     { url = "https://files.pythonhosted.org/packages/cc/af/758e242e9102e9988969b5e621d41f36b8f258bb4a099109b7a4b4b50ea4/torch-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5fd4117d89ffd47e3dcc71e71a22efac24828ad781c7e46aaaf56bf7f2796acf", size = 145996088, upload-time = "2026-01-21T16:24:44.171Z" },
     { url = "https://files.pythonhosted.org/packages/23/8e/3c74db5e53bff7ed9e34c8123e6a8bfef718b2450c35eefab85bb4a7e270/torch-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:787124e7db3b379d4f1ed54dd12ae7c741c16a4d29b49c0226a89bea50923ffb", size = 915711952, upload-time = "2026-01-21T16:23:53.503Z" },
     { url = "https://files.pythonhosted.org/packages/6e/01/624c4324ca01f66ae4c7cd1b74eb16fb52596dce66dbe51eff95ef9e7a4c/torch-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c66c61f44c5f903046cc696d088e21062644cbe541c7f1c4eaae88b2ad23547", size = 113757972, upload-time = "2026-01-21T16:24:39.516Z" },


### PR DESCRIPTION
## Summary

- Catches 403 errors from `Pipeline.from_pretrained` when pyannote models are gated
- Shows a clear error message listing the HuggingFace model pages the user must accept:
  1. https://huggingface.co/pyannote/speaker-diarization-3.1
  2. https://huggingface.co/pyannote/segmentation-3.0
- Non-403 errors are re-raised unchanged

Closes #1

## Before

```
Final diarization failed: 403 Client Error. (Request ID: Root=1-69a1e95b-...)
```

## After

```
RuntimeError: Access denied to gated pyannote models. You must accept the user conditions for each model:
  1. https://huggingface.co/pyannote/speaker-diarization-3.1
  2. https://huggingface.co/pyannote/segmentation-3.0
Then retry. Make sure your HF token has the correct permissions.
```

## Test plan

- [ ] Added unit test that mocks a 403 from `from_pretrained` and verifies the `RuntimeError` with helpful message
- [ ] All 51 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)